### PR TITLE
Add command autocompletion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,6 +48,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee2626afccd7561a06cf1367e2950c4718ea04565e20fb5029b6c7d8ad09abcf"
+
+[[package]]
 name = "either"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -59,6 +65,7 @@ version = "0.1.0"
 dependencies = [
  "direct2d",
  "directwrite",
+ "dyn-clone",
  "winapi",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,4 @@ winapi = { version = "0.3.9", features = [
 ] }
 direct2d = "0.2"
 directwrite = "0.1.4"
+dyn-clone = "1.0.4"

--- a/src/autocomplete_map.rs
+++ b/src/autocomplete_map.rs
@@ -10,6 +10,9 @@ pub struct AutocompleteSuggestion<T: Clone> {
 }
 
 #[derive(Debug, PartialEq, Eq)]
+/// An internal struct representing a potential autocomplete suggestion,
+/// using borrowing and ignoring non-critical fields to ensure that it can
+/// be created in a lightweight way.
 struct CandidateSuggestion<'a> {
     name: &'a str,
     matches: Vec<Range<usize>>,

--- a/src/autocomplete_map.rs
+++ b/src/autocomplete_map.rs
@@ -82,17 +82,17 @@ impl<T: Clone> AutocompleteMap<T> {
         self.entries.insert(name.into(), value);
     }
 
-    pub fn autocomplete<U: Into<String>>(
+    pub fn autocomplete<U: AsRef<str>>(
         &self,
         input: U,
         max_results: usize,
     ) -> Vec<AutocompleteSuggestion<T>> {
         let mut results: Vec<AutocompleteSuggestion<T>> = Vec::with_capacity(max_results);
         let mut candidates: Vec<CandidateSuggestion> = Vec::new();
-        let input_string = input.into();
+        let input_string = input.as_ref();
 
         for name in self.entries.keys() {
-            let matches = get_matches(input_string.as_str(), name.as_str());
+            let matches = get_matches(input_string, name.as_str());
             if !matches.is_empty() {
                 candidates.push(CandidateSuggestion {
                     name: name.as_str(),

--- a/src/autocomplete_map.rs
+++ b/src/autocomplete_map.rs
@@ -4,9 +4,9 @@ use std::ops::Range;
 
 #[derive(Debug, PartialEq)]
 pub struct AutocompleteSuggestion<T: Clone> {
-    name: String,
-    matches: Vec<Range<usize>>,
-    value: T,
+    pub name: String,
+    pub matches: Vec<Range<usize>>,
+    pub value: T,
 }
 
 #[derive(Debug, PartialEq, Eq)]

--- a/src/autocomplete_map.rs
+++ b/src/autocomplete_map.rs
@@ -9,7 +9,7 @@ pub struct AutocompleteSuggestion<T: Clone> {
     value: T,
 }
 
-#[derive(PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 struct CandidateSuggestion<'a> {
     name: &'a str,
     matches: Vec<Range<usize>>,
@@ -69,8 +69,8 @@ fn get_matches(input: &str, name: &str) -> Vec<Range<usize>> {
 
 fn get_best_candidates<'a, I: Iterator<Item = &'a String>>(
     input: &str,
-    max_results: usize,
     names: I,
+    max_results: usize,
 ) -> Vec<CandidateSuggestion<'a>> {
     let mut candidates: Vec<CandidateSuggestion> = Vec::new();
 
@@ -110,7 +110,7 @@ impl<T: Clone> AutocompleteMap<T> {
         max_results: usize,
     ) -> Vec<AutocompleteSuggestion<T>> {
         let mut results: Vec<AutocompleteSuggestion<T>> = Vec::with_capacity(max_results);
-        let candidates = get_best_candidates(input.as_ref(), max_results, self.entries.keys());
+        let candidates = get_best_candidates(input.as_ref(), self.entries.keys(), max_results);
 
         for candidate in candidates.iter() {
             let name = String::from(candidate.name);
@@ -153,6 +153,18 @@ mod tests {
         assert_eq!(
             am.autocomplete("bo", 500),
             vec![sugg("boink", vec![0..2], 3), sugg("boop", vec![0..2], 1)]
+        );
+    }
+
+    #[test]
+    fn test_get_best_candidates_returns_empty_vec() {
+        assert_eq!(
+            get_best_candidates(
+                "bo",
+                [String::from("hi"), String::from("there")].iter(),
+                500
+            ),
+            vec![]
         );
     }
 

--- a/src/autocomplete_map.rs
+++ b/src/autocomplete_map.rs
@@ -1,4 +1,12 @@
 use std::collections::HashMap;
+use std::ops::Range;
+
+#[derive(Debug, PartialEq)]
+pub struct AutocompleteSuggestion<T: Clone> {
+    name: String,
+    matches: Vec<Range<usize>>,
+    value: T,
+}
 
 pub struct AutocompleteMap<T: Clone> {
     entries: HashMap<String, T>,
@@ -15,21 +23,43 @@ impl<T: Clone> AutocompleteMap<T> {
         self.entries.insert(name.into(), value);
     }
 
-    pub fn autocomplete<U: Into<String>>(&self, input: U, max_results: usize) -> Vec<(String, T)> {
-        let mut results: Vec<(String, T)> = Vec::with_capacity(max_results);
+    pub fn autocomplete<U: Into<String>>(
+        &self,
+        input: U,
+        max_results: usize,
+    ) -> Vec<AutocompleteSuggestion<T>> {
+        let mut results = Vec::with_capacity(max_results);
 
         // TODO: Actually filter to input.
-        for (key, value) in self.entries.iter() {
-            results.push((key.clone(), value.clone()));
+        for (name, value) in self.entries.iter() {
+            results.push(AutocompleteSuggestion {
+                name: name.clone(),
+                matches: vec![0..2],
+                value: value.clone(),
+            });
         }
 
         results
     }
 }
 
-#[test]
-fn test_it_works() {
-    let mut am = AutocompleteMap::new();
-    am.insert("boop", 1);
-    assert_eq!(am.autocomplete("bo", 1), vec![(String::from("boop"), 1)]);
+#[cfg(test)]
+mod tests {
+    use super::{AutocompleteMap, AutocompleteSuggestion};
+    use std::ops::Range;
+
+    fn sugg(name: &str, matches: Vec<Range<usize>>, value: usize) -> AutocompleteSuggestion<usize> {
+        AutocompleteSuggestion {
+            name: String::from(name),
+            matches,
+            value,
+        }
+    }
+
+    #[test]
+    fn test_it_works() {
+        let mut am = AutocompleteMap::new();
+        am.insert("boop", 1);
+        assert_eq!(am.autocomplete("bo", 1), vec![sugg("boop", vec![0..2], 1)]);
+    }
 }

--- a/src/autocomplete_map.rs
+++ b/src/autocomplete_map.rs
@@ -1,0 +1,35 @@
+use std::collections::HashMap;
+
+pub struct AutocompleteMap<T: Clone> {
+    entries: HashMap<String, T>,
+}
+
+impl<T: Clone> AutocompleteMap<T> {
+    pub fn new() -> Self {
+        AutocompleteMap {
+            entries: HashMap::new(),
+        }
+    }
+
+    pub fn insert<U: Into<String>>(&mut self, name: U, value: T) {
+        self.entries.insert(name.into(), value);
+    }
+
+    pub fn autocomplete<U: Into<String>>(&self, input: U, max_results: usize) -> Vec<(String, T)> {
+        let mut results: Vec<(String, T)> = Vec::with_capacity(max_results);
+
+        // TODO: Actually filter to input.
+        for (key, value) in self.entries.iter() {
+            results.push((key.clone(), value.clone()));
+        }
+
+        results
+    }
+}
+
+#[test]
+fn test_it_works() {
+    let mut am = AutocompleteMap::new();
+    am.insert("boop", 1);
+    assert_eq!(am.autocomplete("bo", 1), vec![(String::from("boop"), 1)]);
+}

--- a/src/autocomplete_map.rs
+++ b/src/autocomplete_map.rs
@@ -8,6 +8,44 @@ pub struct AutocompleteSuggestion<T: Clone> {
     value: T,
 }
 
+fn get_matches(input: &str, name: &str) -> Vec<Range<usize>> {
+    let mut matches = vec![];
+
+    if name.len() == 0 {
+        return matches;
+    }
+
+    let mut name_idx = 0;
+    let mut curr_match: Option<Range<usize>> = None;
+    let mut input_chars = input.chars();
+    let mut input_char = input_chars.next().unwrap();
+
+    for name_char in name.chars() {
+        if name_char == input_char {
+            curr_match = match curr_match {
+                None => Some(name_idx..name_idx + 1),
+                Some(range) => Some(range.start..name_idx + 1),
+            };
+            if let Some(next_input_char) = input_chars.next() {
+                input_char = next_input_char;
+            } else {
+                break;
+            }
+        } else if let Some(match_) = curr_match {
+            matches.push(match_);
+            curr_match = None;
+        }
+
+        name_idx += 1;
+    }
+
+    if let Some(match_) = curr_match {
+        matches.push(match_);
+    }
+
+    matches
+}
+
 pub struct AutocompleteMap<T: Clone> {
     entries: HashMap<String, T>,
 }
@@ -29,14 +67,17 @@ impl<T: Clone> AutocompleteMap<T> {
         max_results: usize,
     ) -> Vec<AutocompleteSuggestion<T>> {
         let mut results = Vec::with_capacity(max_results);
+        let input_string = input.into();
 
-        // TODO: Actually filter to input.
         for (name, value) in self.entries.iter() {
-            results.push(AutocompleteSuggestion {
-                name: name.clone(),
-                matches: vec![0..2],
-                value: value.clone(),
-            });
+            let matches = get_matches(input_string.as_str(), name.as_str());
+            if !matches.is_empty() {
+                results.push(AutocompleteSuggestion {
+                    name: name.clone(),
+                    matches,
+                    value: value.clone(),
+                })
+            }
         }
 
         results
@@ -60,6 +101,7 @@ mod tests {
     fn test_it_works() {
         let mut am = AutocompleteMap::new();
         am.insert("boop", 1);
+        am.insert("goop", 1);
         assert_eq!(am.autocomplete("bo", 1), vec![sugg("boop", vec![0..2], 1)]);
     }
 }

--- a/src/autocomplete_map.rs
+++ b/src/autocomplete_map.rs
@@ -11,7 +11,7 @@ pub struct AutocompleteSuggestion<T: Clone> {
 fn get_matches(input: &str, name: &str) -> Vec<Range<usize>> {
     let mut matches = vec![];
 
-    if name.len() == 0 {
+    if input.len() == 0 {
         return matches;
     }
 
@@ -86,7 +86,7 @@ impl<T: Clone> AutocompleteMap<T> {
 
 #[cfg(test)]
 mod tests {
-    use super::{AutocompleteMap, AutocompleteSuggestion};
+    use super::*;
     use std::ops::Range;
 
     fn sugg(name: &str, matches: Vec<Range<usize>>, value: usize) -> AutocompleteSuggestion<usize> {
@@ -98,10 +98,26 @@ mod tests {
     }
 
     #[test]
-    fn test_it_works() {
+    fn test_autocomplete_map_works() {
         let mut am = AutocompleteMap::new();
         am.insert("boop", 1);
         am.insert("goop", 1);
         assert_eq!(am.autocomplete("bo", 1), vec![sugg("boop", vec![0..2], 1)]);
+    }
+
+    #[test]
+    fn test_get_matches_returns_empty_vec() {
+        assert_eq!(get_matches("boop", "goop"), vec![]);
+        assert_eq!(get_matches("", "goop"), vec![]);
+    }
+
+    #[test]
+    fn test_get_matches_returns_full_matches() {
+        assert_eq!(get_matches("boop", "boop"), vec![0..4]);
+    }
+
+    #[test]
+    fn test_get_matches_returns_multiple_matches() {
+        assert_eq!(get_matches("boop", "bogus ops"), vec![0..2, 6..8]);
     }
 }

--- a/src/autocomplete_map.rs
+++ b/src/autocomplete_map.rs
@@ -136,12 +136,20 @@ mod tests {
     use super::*;
     use std::ops::Range;
 
+    fn strings<'a>(names: &[&str]) -> Vec<String> {
+        names.iter().map(|name| String::from(*name)).collect()
+    }
+
     fn sugg(name: &str, matches: Vec<Range<usize>>, value: usize) -> AutocompleteSuggestion<usize> {
         AutocompleteSuggestion {
             name: String::from(name),
             matches,
             value,
         }
+    }
+
+    fn cand(name: &'static str, matches: Vec<Range<usize>>) -> CandidateSuggestion {
+        CandidateSuggestion { name, matches }
     }
 
     #[test]
@@ -157,14 +165,26 @@ mod tests {
     }
 
     #[test]
-    fn test_get_best_candidates_returns_empty_vec() {
+    fn test_get_best_candidates_ignores_nonmatches() {
         assert_eq!(
-            get_best_candidates(
-                "bo",
-                [String::from("hi"), String::from("there")].iter(),
-                500
-            ),
+            get_best_candidates("bo", strings(&["hi", "there"]).iter(), 500),
             vec![]
+        );
+    }
+
+    #[test]
+    fn test_get_best_candidates_returns_sorted_matches() {
+        assert_eq!(
+            get_best_candidates("bo", strings(&["boop", "boink"]).iter(), 500),
+            vec![cand("boink", vec![0..2]), cand("boop", vec![0..2])]
+        );
+    }
+
+    #[test]
+    fn test_get_best_candidates_truncates_matches() {
+        assert_eq!(
+            get_best_candidates("bo", strings(&["boop", "boink"]).iter(), 1),
+            vec![cand("boink", vec![0..2])]
         );
     }
 

--- a/src/autocomplete_map.rs
+++ b/src/autocomplete_map.rs
@@ -40,6 +40,7 @@ fn get_matches(input: &str, name: &str) -> Vec<Range<usize>> {
     let mut curr_match: Option<Range<usize>> = None;
     let mut input_chars = input.chars();
     let mut input_char = input_chars.next().unwrap();
+    let mut input_chars_matched = 0;
 
     for name_char in name.chars() {
         if name_char == input_char {
@@ -47,6 +48,7 @@ fn get_matches(input: &str, name: &str) -> Vec<Range<usize>> {
                 None => Some(name_idx..name_idx + 1),
                 Some(range) => Some(range.start..name_idx + 1),
             };
+            input_chars_matched += 1;
             if let Some(next_input_char) = input_chars.next() {
                 input_char = next_input_char;
             } else {
@@ -62,6 +64,10 @@ fn get_matches(input: &str, name: &str) -> Vec<Range<usize>> {
 
     if let Some(match_) = curr_match {
         matches.push(match_);
+    }
+
+    if input_chars_matched != input.len() {
+        matches.clear();
     }
 
     matches
@@ -192,6 +198,11 @@ mod tests {
     fn test_get_matches_returns_empty_vec() {
         assert_eq!(get_matches("boop", "goop"), vec![]);
         assert_eq!(get_matches("", "goop"), vec![]);
+    }
+
+    #[test]
+    fn test_get_matches_only_works_when_all_chars_match() {
+        assert_eq!(get_matches("boop", "bop"), vec![]);
     }
 
     #[test]

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,4 +1,3 @@
-use super::autocomplete_map::AutocompleteMap;
 use super::error::Error;
 use super::ui::UserInterface;
 use dyn_clone::DynClone;
@@ -37,30 +36,6 @@ impl<F: FnMut(&mut UserInterface) -> Result<(), Error> + Clone> Command for Simp
     fn execute(&mut self, ui: &mut UserInterface) -> Result<(), Error> {
         (self.execute_)(ui)
     }
-}
-
-pub struct CommandRegistry {
-    acm: AutocompleteMap<Box<dyn Command>>,
-}
-
-impl CommandRegistry {
-    pub fn new() -> CommandRegistry {
-        CommandRegistry {
-            acm: AutocompleteMap::new(),
-        }
-    }
-
-    pub fn register(&mut self, command: Box<dyn Command>) {
-        self.acm.insert(command.name(), command);
-    }
-}
-
-fn tada_command() -> Box<dyn Command> {
-    SimpleCommand::new("tada", |ui| {
-        ui.type_char("🎉")?;
-        Ok(())
-    })
-    .into_box()
 }
 
 #[test]

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,13 +1,35 @@
 use super::error::Error;
+use super::ui::UserInterface;
+use dyn_clone::DynClone;
 
-pub trait CommandUI {
-    fn quit(&mut self);
+pub trait Command: DynClone {
+    fn name(&self) -> String;
+    fn execute(&mut self, ui: &mut UserInterface) -> Result<(), Error>;
 }
 
-pub trait Command {
-    fn name(&self) -> String;
-    fn help(&self) -> String;
-    fn execute(&mut self, ui: &mut dyn CommandUI) -> Result<(), Error>;
+#[derive(Clone)]
+pub struct SimpleCommand<F: FnMut(&mut UserInterface) -> Result<(), Error> + Clone> {
+    name_: String,
+    execute_: F,
+}
+
+impl<F: FnMut(&mut UserInterface) -> Result<(), Error> + Clone> SimpleCommand<F> {
+    pub fn new<T: Into<String>>(name: T, execute: F) -> Self {
+        SimpleCommand {
+            name_: name.into(),
+            execute_: execute,
+        }
+    }
+}
+
+impl<F: FnMut(&mut UserInterface) -> Result<(), Error> + Clone> Command for SimpleCommand<F> {
+    fn name(&self) -> String {
+        self.name_.clone()
+    }
+
+    fn execute(&mut self, ui: &mut UserInterface) -> Result<(), Error> {
+        (self.execute_)(ui)
+    }
 }
 
 pub struct CommandRegistry {
@@ -24,4 +46,20 @@ impl CommandRegistry {
     pub fn register(&mut self, command: Box<dyn Command>) {
         self.commands.push(command);
     }
+}
+
+fn tada_command() -> Box<dyn Command> {
+    Box::new(SimpleCommand::new("tada", |ui| {
+        ui.type_char("🎉")?;
+        Ok(())
+    }))
+}
+
+#[test]
+fn test_simple_command_works() {
+    let cmd = SimpleCommand::new("hi", |ui| {
+        ui.show_message("HALLO")?;
+        Ok(())
+    });
+    let _cmd2 = cmd.clone();
 }

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,0 +1,27 @@
+use super::error::Error;
+
+pub trait CommandUI {
+    fn quit(&mut self);
+}
+
+pub trait Command {
+    fn name(&self) -> String;
+    fn help(&self) -> String;
+    fn execute(&mut self, ui: &mut dyn CommandUI) -> Result<(), Error>;
+}
+
+pub struct CommandRegistry {
+    commands: Vec<Box<dyn Command>>,
+}
+
+impl CommandRegistry {
+    pub fn new() -> CommandRegistry {
+        CommandRegistry {
+            commands: Vec::new(),
+        }
+    }
+
+    pub fn register(&mut self, command: Box<dyn Command>) {
+        self.commands.push(command);
+    }
+}

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,3 +1,4 @@
+use super::autocomplete_map::AutocompleteMap;
 use super::error::Error;
 use super::ui::UserInterface;
 use dyn_clone::DynClone;
@@ -6,6 +7,8 @@ pub trait Command: DynClone {
     fn name(&self) -> String;
     fn execute(&mut self, ui: &mut UserInterface) -> Result<(), Error>;
 }
+
+dyn_clone::clone_trait_object!(Command);
 
 #[derive(Clone)]
 pub struct SimpleCommand<F: FnMut(&mut UserInterface) -> Result<(), Error> + Clone> {
@@ -37,18 +40,18 @@ impl<F: FnMut(&mut UserInterface) -> Result<(), Error> + Clone> Command for Simp
 }
 
 pub struct CommandRegistry {
-    commands: Vec<Box<dyn Command>>,
+    acm: AutocompleteMap<Box<dyn Command>>,
 }
 
 impl CommandRegistry {
     pub fn new() -> CommandRegistry {
         CommandRegistry {
-            commands: Vec::new(),
+            acm: AutocompleteMap::new(),
         }
     }
 
     pub fn register(&mut self, command: Box<dyn Command>) {
-        self.commands.push(command);
+        self.acm.insert(command.name(), command);
     }
 }
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -21,7 +21,7 @@ impl<F: FnMut(&mut UserInterface) -> Result<(), Error> + Clone> SimpleCommand<F>
         }
     }
 
-    pub fn into_box(self) -> Box<SimpleCommand<F>> {
+    pub fn into_box(self) -> Box<Self> {
         Box::new(self)
     }
 }

--- a/src/command.rs
+++ b/src/command.rs
@@ -20,6 +20,10 @@ impl<F: FnMut(&mut UserInterface) -> Result<(), Error> + Clone> SimpleCommand<F>
             execute_: execute,
         }
     }
+
+    pub fn into_box(self) -> Box<SimpleCommand<F>> {
+        Box::new(self)
+    }
 }
 
 impl<F: FnMut(&mut UserInterface) -> Result<(), Error> + Clone> Command for SimpleCommand<F> {
@@ -49,10 +53,11 @@ impl CommandRegistry {
 }
 
 fn tada_command() -> Box<dyn Command> {
-    Box::new(SimpleCommand::new("tada", |ui| {
+    SimpleCommand::new("tada", |ui| {
         ui.type_char("🎉")?;
         Ok(())
-    }))
+    })
+    .into_box()
 }
 
 #[test]
@@ -60,6 +65,7 @@ fn test_simple_command_works() {
     let cmd = SimpleCommand::new("hi", |ui| {
         ui.show_message("HALLO")?;
         Ok(())
-    });
+    })
+    .into_box();
     let _cmd2 = cmd.clone();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,16 @@ mod transparent_window;
 mod ui;
 mod windows_util;
 
+use command::{Command, SimpleCommand};
+
+fn tada_command() -> Box<dyn Command> {
+    SimpleCommand::new("tada", |ui| {
+        ui.type_char("🎉")?;
+        Ok(())
+    })
+    .into_box()
+}
+
 fn run_enso() -> Result<(), Box<error::Error>> {
     use std::sync::mpsc::channel;
 
@@ -30,6 +40,8 @@ fn run_enso() -> Result<(), Box<error::Error>> {
 
     let keyhook = keyboard_hook::KeyboardHook::install(tx, eloop.get_thread_id());
     let mut ui = ui::UserInterface::new(d3d_device)?;
+
+    ui.add_command(tada_command());
 
     ui.show_message("Welcome to Enso!")?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@
 
 extern crate winapi;
 
+mod autocomplete_map;
 mod command;
 mod directx;
 mod error;

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ mod error;
 mod event_loop;
 mod events;
 mod keyboard_hook;
+mod menu;
 mod transparent_window;
 mod ui;
 mod windows_util;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@
 
 extern crate winapi;
 
+mod command;
 mod directx;
 mod error;
 mod event_loop;

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,11 +19,7 @@ mod windows_util;
 use command::{Command, SimpleCommand};
 
 fn tada_command() -> Box<dyn Command> {
-    SimpleCommand::new("tada", |ui| {
-        ui.type_char("🎉")?;
-        Ok(())
-    })
-    .into_box()
+    SimpleCommand::new("tada", |ui| ui.type_char("🎉")).into_box()
 }
 
 fn run_enso() -> Result<(), Box<error::Error>> {

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -1,0 +1,81 @@
+pub struct Menu<T> {
+    entries: Vec<T>,
+    pub selected_idx: usize,
+}
+
+impl<T> Menu<T> {
+    pub fn into_selected_entry(mut self) -> Option<T> {
+        if self.selected_idx < self.entries.len() {
+            Some(self.entries.remove(self.selected_idx))
+        } else {
+            None
+        }
+    }
+
+    // https://depth-first.com/articles/2020/06/22/returning-rust-iterators/
+    pub fn iter(&self) -> impl Iterator<Item = (&T, bool)> + '_ {
+        self.entries
+            .iter()
+            .enumerate()
+            .map(move |(idx, entry)| (entry, idx == self.selected_idx))
+    }
+
+    pub fn select_next(&mut self) {
+        if self.entries.len() > 0 && self.selected_idx < self.entries.len() - 1 {
+            self.selected_idx += 1;
+        } else {
+            self.selected_idx = 0;
+        }
+    }
+
+    pub fn select_prev(&mut self) {
+        if self.selected_idx > 0 {
+            self.selected_idx -= 1;
+        } else if self.entries.len() > 0 {
+            self.selected_idx = self.entries.len() - 1;
+        }
+    }
+}
+
+impl<T> From<Vec<T>> for Menu<T> {
+    fn from(entries: Vec<T>) -> Menu<T> {
+        Menu {
+            entries,
+            selected_idx: 0,
+        }
+    }
+}
+
+#[test]
+fn test_it_works_with_filled_vec() {
+    let mut menu = Menu::from(vec![1, 2, 3]);
+    assert_eq!(menu.selected_idx, 0);
+    menu.select_next();
+    assert_eq!(menu.selected_idx, 1);
+    menu.select_prev();
+    assert_eq!(menu.selected_idx, 0);
+    menu.select_prev();
+    assert_eq!(menu.selected_idx, 2);
+    menu.select_next();
+    assert_eq!(menu.selected_idx, 0);
+
+    let mut menu_items: Vec<(i32, bool)> = vec![];
+
+    for (value, is_selected) in menu.iter() {
+        menu_items.push((*value, is_selected));
+    }
+
+    assert_eq!(menu_items, vec![(1, true), (2, false), (3, false),]);
+
+    assert_eq!(menu.into_selected_entry(), Some(1));
+}
+
+#[test]
+fn test_it_works_with_empty_vec() {
+    let mut menu: Menu<i32> = Menu::from(vec![]);
+    menu.select_next();
+    assert_eq!(menu.selected_idx, 0);
+    menu.select_prev();
+    assert_eq!(menu.selected_idx, 0);
+    assert_eq!(menu.into_selected_entry(), None);
+}

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -10,6 +10,10 @@ impl<T> Menu<T> {
         self.entries.remove(self.selected_idx)
     }
 
+    pub fn selected_entry(&self) -> &T {
+        self.entries.get(self.selected_idx).unwrap()
+    }
+
     // https://depth-first.com/articles/2020/06/22/returning-rust-iterators/
     pub fn iter(&self) -> impl Iterator<Item = (&T, bool)> + '_ {
         self.entries

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -25,6 +25,7 @@ const DEFAULT_FG: ColorAlpha = (0xFF_FF_FF, 1.0);
 const HELP_BG: ColorAlpha = (0x7F_98_45, 0.75);
 const HELP_FG: ColorAlpha = DEFAULT_FG;
 const AUTOCOMPLETED_FG: ColorAlpha = (0x7F_98_45, 1.0);
+const UNSELECTED_INPUT_FG: ColorAlpha = (0xAF_BC_92, 1.0);
 const FONT_FAMILY: &'static str = "Georgia";
 const FONT_SIZE: f32 = 48.0;
 const SMALL_FONT_SIZE: f32 = 24.0;
@@ -49,6 +50,7 @@ struct Brushes {
     pub help_bg: SolidColorBrush,
     pub help_fg: SolidColorBrush,
     pub autocompleted_fg: SolidColorBrush,
+    pub unselected_input_fg: SolidColorBrush,
 }
 
 impl Brushes {
@@ -59,6 +61,7 @@ impl Brushes {
             help_bg: make_simple_brush(target, HELP_BG)?,
             help_fg: make_simple_brush(target, HELP_FG)?,
             autocompleted_fg: make_simple_brush(target, AUTOCOMPLETED_FG)?,
+            unselected_input_fg: make_simple_brush(target, UNSELECTED_INPUT_FG)?,
         })
     }
 }


### PR DESCRIPTION
This adds a more formal notion of what a "command" consists of, and shows auto-completion results as the user types, along with providing the ability for the results to be chosen via the up/down arrow keys.

Commands are defined by a new `Command` trait, with a concrete implementation in `SimpleCommand` which allows for commands to be defined via simple functions, like this:

```rust
fn tada_command() -> Box<dyn Command> {
    SimpleCommand::new("tada", |ui| ui.type_char("🎉")).into_box()
}

ui.add_command(tada_command());
```

The `dyn_clone` crate is used to make it easy for commands to be cloned (figuring this out was a lot harder than I expected it to be).

At first I was going to make a giant struct to handle all of this, but then I realized that it would be really hard to test, so I split it up into a couple of generics that cooperate with one another:

* `AutocompleteMap<T>` takes care of keeping track of autocompletions and coming up with the best available ones for a given input string.
* `Menu<T>` takes care of allowing the user to choose between multiple autocomplete suggestions.
