### PR TITLE
Disable caps lock on Enso start.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,8 @@ fn run_enso() -> Result<(), Box<error::Error>> {
     let eloop = event_loop::EventLoop::new();
     let (tx, rx) = channel();
 
+    windows_util::disable_caps_lock()?;
+
     let keyhook = keyboard_hook::KeyboardHook::install(tx, eloop.get_thread_id());
     let mut ui = ui::UserInterface::new(d3d_device)?;
 

--- a/src/windows_util.rs
+++ b/src/windows_util.rs
@@ -128,6 +128,11 @@ fn test_get_primary_screen_size() {
     assert!(get_primary_screen_size().is_ok());
 }
 
+#[test]
+fn test_disable_caps_lock() {
+    assert!(disable_caps_lock().is_ok());
+}
+
 pub fn vkey_to_char(vk_code: i32) -> Option<char> {
     match vk_code {
         VK_0..=VK_9 | VK_A..=VK_Z => Some(char::from(vk_code as u8)),


### PR DESCRIPTION
Fixes #12.

The code for disabling caps lock was largely cribbed from the old C++ implementation for [`InputManager::setCapsLockMode()`][1].

[1]: https://github.com/toolness/community-enso/blob/e688e14628765235bf3575401192fc66f4c57236/src/platform/win32/InputManager/InputManager.cxx#L171
